### PR TITLE
chore: update Go version to 1.22 and adjust test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     name: "go test"
     strategy:
       matrix:
-        go-version: [ 1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x ]
+        go-version: [ 1.22.x, 1.23.x, 1.24.x ]
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-twca
 
-go 1.18
+go 1.22
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Updated the automated testing setup to focus on current Go versions (1.22, 1.23, and 1.24) for improved compatibility.
- **Chores**
	- Revised module requirements to mandate Go 1.22 or newer, ensuring streamlined support and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->