### PR TITLE
ci: support Go 1.25 and upgrade mod to 1.24.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     name: "go test"
     strategy:
       matrix:
-        go-version: [ 1.22.x, 1.23.x, 1.24.x ]
+        go-version: [ 1.24.x, 1.25.x ]
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-twca
 
-go 1.22
+go 1.24.0
 
 require github.com/stretchr/testify v1.11.1
 


### PR DESCRIPTION
- Update Go version in go.mod from 1.22 to1.24.0
- Modify GitHub Actions test matrix to use Go 1.24.x and1.25.x
- Remove 1.22.x and1.23.x from the test matrix